### PR TITLE
Fixing bytecode compilation for non top level return statements.

### DIFF
--- a/src/norswap/sigh/bytecode/BytecodeCompiler.java
+++ b/src/norswap/sigh/bytecode/BytecodeCompiler.java
@@ -627,7 +627,7 @@ public class BytecodeCompiler
                 invokeStatic(method, Boolean.class, "valueOf", boolean.class);
             method.visitInsn(ARETURN);
         } else {
-            method.visitInsn(nodeAsmType(node).getOpcode(IRETURN));
+            method.visitInsn(nodeAsmType(node.expression).getOpcode(IRETURN));
         }
 
         return null;

--- a/test/BytecodeTests.java
+++ b/test/BytecodeTests.java
@@ -251,6 +251,7 @@ public class BytecodeTests
     }
 
     @Test public void testMethod() {
+        check("fun test (x: String):String { return x } print(test(\"a\"))", "a");
         check("fun test (x: String) { print(x) } ; test(\"a\")", "a");
         check("fun test () { fun foo() { print(\"a\") } foo() foo() } test()", "a\na");
     }


### PR DESCRIPTION
Fixes #1 
When calculating the ASM type to generate bytecode on a non top level return statement it was trying to retrieve the type from the return statement node itself instead of getting the type from the expression node inside the return.